### PR TITLE
Add y/N confirmation before project registration

### DIFF
--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import { spawnSync } from 'child_process';
 import { readFileSync } from 'fs';
-import { createInterface } from 'readline/promises';
+import { createInterface } from 'readline';
 import { stdin as input, stdout as output } from 'process';
 import { loadConfig, requireAuth } from '../config.js';
 import { TahApiClient } from '../api.js';
@@ -84,20 +84,24 @@ async function syncProjectIssues(api: TahApiClient, project: Project, dryRun: bo
   }
 }
 
-async function confirmProjectRegistration(owner: string, repo: string, languages: string[]): Promise<boolean> {
+async function confirmProjectRegistration(owner: string, repo: string, languages: string[], skipConfirmation = false): Promise<boolean> {
   console.log('Project to register:');
   console.log(`  Owner:     ${owner}`);
   console.log(`  Repo:      ${repo}`);
   console.log(`  Languages: ${languages.join(', ')}`);
 
+  if (skipConfirmation) {
+    return true;
+  }
+
   if (!input.isTTY || !output.isTTY) {
-    console.log('\nSubmit? [y/N] n');
+    console.error('Interactive confirmation required. Re-run with --yes to register non-interactively.');
     return false;
   }
 
   const rl = createInterface({ input, output });
   try {
-    const answer = await rl.question('\nSubmit? [y/N] ');
+    const answer = await new Promise<string>((resolve) => rl.question('\nSubmit? [y/N] ', resolve));
     return answer.trim().toLowerCase() === 'y';
   } finally {
     rl.close();
@@ -117,12 +121,14 @@ export function projectCommand(): Command {
     .option('--max-concurrent <n>', 'Max concurrent tasks', '3')
     .option('--trust-threshold <n>', 'Min contributor trust score (0–1) to receive tasks', '0')
     .option('--claude-md <file>', 'Path to a CLAUDE.md file to inject as project context for contributors')
+    .option('-y, --yes', 'Skip confirmation prompt')
     .action(async (owner: string, repo: string, opts: {
       languages: string;
       label: string;
       maxConcurrent: string;
       trustThreshold: string;
       claudeMd?: string;
+      yes?: boolean;
     }) => {
       const config = loadConfig();
       requireAuth(config);
@@ -163,7 +169,7 @@ export function projectCommand(): Command {
         }
       }
 
-      const confirmed = await confirmProjectRegistration(owner, repo, languages);
+      const confirmed = await confirmProjectRegistration(owner, repo, languages, opts.yes === true);
       if (!confirmed) {
         console.log('Canceled. Project was not submitted.');
         return;

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'tsup';
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm'],
+  platform: 'node',
   dts: false,
   sourcemap: true,
   clean: true,


### PR DESCRIPTION
## Summary
- add an interactive confirmation step before `tah project register` submits
- print a short submission summary (owner/repo/languages) before prompting
- exit cleanly without submitting when response is not `y`

## Testing
- `corepack pnpm --filter @tah/cli test`

Closes #4