### PR TITLE
fix(cli): mask auth token in config display

### DIFF
--- a/packages/cli/src/commands/config.test.ts
+++ b/packages/cli/src/commands/config.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { maskAuthToken } from './config.js';
+
+describe('maskAuthToken', () => {
+  it('returns placeholder when token is missing', () => {
+    expect(maskAuthToken(undefined)).toBe('(not set)');
+  });
+
+  it('masks short tokens without revealing suffix', () => {
+    expect(maskAuthToken('abcd123')).toBe('a***');
+  });
+
+  it('masks long tokens with prefix and suffix visible', () => {
+    expect(maskAuthToken('sk-1234567890f9e2')).toBe('sk-***...f9e2');
+  });
+});

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -4,21 +4,55 @@ import { loadConfig, saveConfig } from '../config.js';
 const SETTABLE_KEYS = ['coordinatorUrl'] as const;
 type SettableKey = (typeof SETTABLE_KEYS)[number];
 
+const MASKED_TOKEN_PLACEHOLDER = '***';
+
+export function maskAuthToken(token?: string): string {
+  if (!token) return '(not set)';
+  if (token.length <= 8) return `${token.slice(0, 1)}${MASKED_TOKEN_PLACEHOLDER}`;
+  return `${token.slice(0, 3)}${MASKED_TOKEN_PLACEHOLDER}...${token.slice(-4)}`;
+}
+
+function showConfig(): void {
+  const config = loadConfig();
+
+  console.log(`coordinatorUrl: ${config.coordinatorUrl}`);
+  console.log(`contributorId:  ${config.contributorId ?? '(not set)'}`);
+  console.log(`authToken:      ${maskAuthToken(config.authToken)}`);
+}
+
+function setConfigValue(key: string, value: string): void {
+  if (!SETTABLE_KEYS.includes(key as SettableKey)) {
+    console.error(`Unknown config key: ${key}`);
+    console.error(`Valid keys: ${SETTABLE_KEYS.join(', ')}`);
+    process.exit(1);
+  }
+  const config = loadConfig();
+  saveConfig({ ...config, [key]: value });
+  console.log(`Set ${key} = ${value}`);
+}
+
 export function configCommand(): Command {
   const cmd = new Command('config').description('Get or set tah configuration');
 
   cmd
-    .argument('<key>', `Config key: ${SETTABLE_KEYS.join(' | ')}`)
-    .argument('<value>', 'Value to set')
-    .action((key: string, value: string) => {
-      if (!SETTABLE_KEYS.includes(key as SettableKey)) {
-        console.error(`Unknown config key: ${key}`);
-        console.error(`Valid keys: ${SETTABLE_KEYS.join(', ')}`);
+    .command('show')
+    .description('Display current configuration (auth token is masked)')
+    .action(showConfig);
+
+  cmd
+    .argument('[key]', `Config key: ${SETTABLE_KEYS.join(' | ')}`)
+    .argument('[value]', 'Value to set')
+    .action((key?: string, value?: string) => {
+      if (!key && !value) {
+        showConfig();
+        return;
+      }
+      if (!key || !value) {
+        console.error('Usage: tah config [key] [value] or tah config show');
         process.exit(1);
       }
-      const config = loadConfig();
-      saveConfig({ ...config, [key]: value });
-      console.log(`Set ${key} = ${value}`);
+
+      setConfigValue(key, value);
     });
 
   return cmd;


### PR DESCRIPTION
## Summary
- add `tah config show` command to display current config values
- mask `authToken` output to avoid leaking full credentials in terminal screenshots/logs
- keep existing `tah config <key> <value>` flow for updates
- add unit tests for token masking behavior

## Testing
- `corepack pnpm --filter @tah/cli test`
- `corepack pnpm --filter @tah/cli typecheck`

Closes #5
